### PR TITLE
set title as current directory

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -2,6 +2,7 @@ module Main where
 
 import qualified Control.Monad as M
 import qualified System.Environment as E
+import qualified System.FilePath as F
 import qualified System.Process as P
 
 main :: IO ()
@@ -16,5 +17,5 @@ getTargetDirectory =
 
 runMinttyAt :: String -> IO ()
 runMinttyAt targetDirectory = do
-  let mintty = (P.proc "mintty" []){ P.cwd = Just targetDirectory }
+  let mintty = (P.proc "mintty" ["--title", F.takeFileName targetDirectory]){ P.cwd = Just targetDirectory }
   M.void $ P.createProcess mintty

--- a/open-msys2-mintty.cabal
+++ b/open-msys2-mintty.cabal
@@ -18,6 +18,7 @@ executable open-msys2-mintty
   main-is:             Main.hs
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N -Wall
   build-depends:       base >= 4.7 && < 5
+                     , filepath >= 1.4 && < 2
                      , process >= 1.2 && < 2
   default-language:    Haskell2010
 


### PR DESCRIPTION
# Motivation

I usually open a mintty window at every project directory.
This modification makes it easier to tell which project the mintty window is opened for,
when I open several mintty windows,
